### PR TITLE
Feat/odin infrastructure

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,1 @@
+AOC_SESSION=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ inputs/
 
 .DS_Store
 .env
+./aocday-bench

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ inputs/
 /tmp/
 
 .DS_Store
+.env

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -9,58 +9,41 @@ vars:
     sh: date +%d
 
 tasks:
-  test2:
-    cmds:
-      - echo {{.YEAR}}
-      - echo {{.DAY}}
-      - echo "{{.AOC_SESSION}}"
-
   run:
-    desc: "Run a day's solution: task run -- 1 [--test]"
+    desc: "Run a day's solution"
     cmds:
       - >
         odin run ./{{.YEAR}}/day{{.DAY}}
         -- {{.CLI_ARGS}}
 
   bench:
-    desc: "Benchmark a day: task bench -- 1 1"
+    desc: "Benchmark a given day using hyperfine"
     cmds:
       - >
-        odin build {{.YEAR}}/day{{printf "%02d" (index .CLI_ARGS 0 | int)}}
-        -collection:aoclib=./aoclib
-        -out:/tmp/aocday -o:speed
-      - hyperfine -w 2 "/tmp/aocday {{index .CLI_ARGS 1}}"
+        odin build {{ .YEAR }}/day{{ .DAY }}
+        -out:./aocday-bench -o:speed
+      - defer: rm ./aocday-bench
+      - hyperfine -w 2 -N "./aocday-bench {{ .CLI_ARGS }}"
 
   test:
-    desc: "Test a day: task test -- 1  (omit args to test all days)"
-    cmds:
-      - task: test:one
-        vars: { DAY: '{{index .CLI_ARGS 0}}' }
-    status:
-      - test -z "{{.CLI_ARGS}}"
-
-  test:one:
-    internal: true
-    cmds:
-      - odin test {{.YEAR}}/day{{printf "%02d" (.DAY | int)}} -collection:aoclib=./aoclib
-
-  test:all:
-    desc: "Run every day's tests"
-    cmds:
-      - for d in {{.YEAR}}/day*/; do odin test "$d" -collection:aoclib=./aoclib; done
+    desc: "Run the tests for the aoclib"
+    cmd: odin test ./tests -all-packages
 
   new:
-    desc: "Scaffold a new day: task new -- 3"
+    desc: "Scaffold a new day"
+    status:
+      - test -f ./{{.YEAR}}/day{{.DAY}}/main.odin
     cmds:
-      - ./scripts/new_day.sh {{ .CLI_ARGS }} {{.YEAR}}
+      - ./scripts/new_day.sh {{.YEAR}} {{.DAY}}
+      - task: get
 
   get:
-    desc: "Fetch puzzle input: task get -- 3"
+    desc: "Fetch puzzle input"
     vars:
       AOC_SESSION:
         secret: true
         sh: echo $AOC_SESSION
+    status:
+      - test -f ./inputs/{{.YEAR}}/{{.DAY}}.in
     cmds:
        - ./scripts/fetch_input.sh {{.YEAR}} {{.DAY}} {{.AOC_SESSION}}
-    requires:
-      vars: [AOC_SESSION]

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,16 +1,26 @@
 version: '3'
 
+dotenv: ['.env']
+
 vars:
-  YEAR: '2025'
+  YEAR:
+    sh: date +%Y
+  DAY:
+    sh: date +%d
 
 tasks:
+  test2:
+    cmds:
+      - echo {{.YEAR}}
+      - echo {{.DAY}}
+      - echo "{{.AOC_SESSION}}"
+
   run:
-    desc: "Run a day's solution: task run -- 1 1 [--test]"
+    desc: "Run a day's solution: task run -- 1 [--test]"
     cmds:
       - >
-        odin run {{.YEAR}}/day{{printf "%02d" (index .CLI_ARGS 0 | int)}}
-        -collection:aoclib=./aoclib
-        -- {{index .CLI_ARGS 1}} {{if eq (len .CLI_ARGS) 3}}{{index .CLI_ARGS 2}}{{end}}
+        odin run ./{{.YEAR}}/day{{.DAY}}
+        -- {{.CLI_ARGS}}
 
   bench:
     desc: "Benchmark a day: task bench -- 1 1"
@@ -46,7 +56,11 @@ tasks:
 
   get:
     desc: "Fetch puzzle input: task get -- 3"
+    vars:
+      AOC_SESSION:
+        secret: true
+        sh: echo $AOC_SESSION
     cmds:
-      - ./scripts/fetch_input.sh {{index .CLI_ARGS 0}} {{.YEAR}}
+       - ./scripts/fetch_input.sh {{.YEAR}} {{.DAY}} {{.AOC_SESSION}}
     requires:
       vars: [AOC_SESSION]

--- a/aoclib/array.odin
+++ b/aoclib/array.odin
@@ -1,6 +1,5 @@
 package aoclib
 
-import "core:fmt"
 import "core:strconv"
 
 map_to :: proc (input: []string, f: proc(string) -> $T, allocator := context.temp_allocator) -> []T {

--- a/scripts/fetch_input.sh
+++ b/scripts/fetch_input.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+trap 'echo "Error on line $LINENO"' ERR
+
+INPUT="./inputs/$1/$2.in"
+
+curl --silent \
+    -o "./inputs/$1/$2.in" \
+    --cookie "session=$3" \
+    "https://adventofcode.com/$1/day/$(($2))/input"
+
+echo "Created input at: $INPUT"

--- a/scripts/new_day.sh
+++ b/scripts/new_day.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
-day=$1
-year=${2:-2025}
-padded=$(printf '%02d' "$day")
-dir="${year}/day${padded}"
+
+year=$1
+day=$(printf '%02d' "$2")
+
+dir="${year}/day${day}"
 
 mkdir -p "$dir"
-sed -e "s/{{day}}/${day}/g" -e "s/{{year}}/${year}/g" templates/day_template.odin > "$dir/main.odin"
+sed -e "s/{{day}}/$((day))/g" -e "s/{{year}}/${year}/g" templates/day_template.odin > "$dir/main.odin"
 
 echo "Created $dir"

--- a/tests/aoclib/app.odin
+++ b/tests/aoclib/app.odin
@@ -1,0 +1,8 @@
+package aoclib_tests
+
+import "core:testing"
+
+@(test)
+runs_correct_part :: proc (t: ^testing.T) {
+	testing.expect(t, false)
+}

--- a/tests/aoclib/math/point.odin
+++ b/tests/aoclib/math/point.odin
@@ -1,0 +1,8 @@
+package aoclib_math_tests
+
+import "core:testing"
+
+@(test)
+calculates_distance_test :: proc(t: ^testing.T) {
+	testing.expect(t, false)
+}

--- a/tests/tests.odin
+++ b/tests/tests.odin
@@ -1,0 +1,4 @@
+package tests
+
+@require import "aoclib"
+@require import "aoclib/math"


### PR DESCRIPTION
This MR replaces the generated task file with a working one:

- `task run` will now run the current day
- `task bench` will benchmark the current day using hyperfine
- `task test` will now run the test suite of the aoclib that is included in the repository
- `task new` will now bootstrap the current day (create the required odin file that is ready to run as well as run `task get`
- `task get` will now fetch the input for the current day

For all tasks the variables `YEAR` and `DAY` can be overwritten to not use the current but any other day of AOC